### PR TITLE
Fix missing EGL/GLVND configs and GBM search path in generated CDI spec

### DIFF
--- a/nvidia-driver.plg
+++ b/nvidia-driver.plg
@@ -323,7 +323,12 @@ fi
 }
 
 generate_cdi() {
-  nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml >/dev/null 2>&amp;1
+  # CDI generation is handled by the disks_mounted event hook so it runs after
+  # /var/lib/docker is mounted (the EGL/GLVND vendor JSONs the .txz doesn't
+  # ship on the host get staged from the libnvidia-container volume there).
+  # Trigger it now for the manual plugin install/upgrade case; on boot Unraid
+  # fires the event itself once the array comes up.
+  [ -x &emhttp;/event/disks_mounted ] &amp;&amp; &emhttp;/event/disks_mounted
 }
 
 #Create settings file if not found

--- a/source/compile.sh
+++ b/source/compile.sh
@@ -105,6 +105,12 @@ $TARGET_V"
   cp /usr/bin/nvidia-modprobe /NVIDIA/usr/bin/
   cp -R /etc/OpenCL /NVIDIA/etc/
   cp -R /etc/vulkan /NVIDIA/etc/
+  # The NVIDIA installer writes the EGL/GLVND vendor JSONs to system paths that
+  # ignore --x-prefix; capture them so containers using --gpus all can find
+  # libEGL_nvidia.so.0 and the GBM/Wayland external platforms.
+  mkdir -p /NVIDIA/usr/share/glvnd/egl_vendor.d /NVIDIA/usr/share/egl/egl_external_platform.d
+  cp /usr/share/glvnd/egl_vendor.d/*nvidia*.json /NVIDIA/usr/share/glvnd/egl_vendor.d/ 2>/dev/null || true
+  cp /usr/share/egl/egl_external_platform.d/*nvidia*.json /NVIDIA/usr/share/egl/egl_external_platform.d/ 2>/dev/null || true
 
 
   cd ${DATA_DIR}

--- a/source/usr/local/emhttp/plugins/nvidia-driver/event/disks_mounted
+++ b/source/usr/local/emhttp/plugins/nvidia-driver/event/disks_mounted
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Fires after the array is up (cache disk mounted, /var/lib/docker available)
+# and before rc.docker starts the daemon. Stages the EGL/GLVND vendor JSONs
+# the driver package doesn't install on the host so nvidia-ctk's graphics
+# discoverer includes them in the CDI spec, regenerates the spec, and appends
+# GBM_BACKENDS_PATH for Debian-multiarch containers.
+EGL_SRC=/var/lib/docker/volumes/nvidia-driver-vol/_data/share
+if [ -d "$EGL_SRC" ]; then
+  for f in "$EGL_SRC"/glvnd/egl_vendor.d/*nvidia*.json "$EGL_SRC"/egl/egl_external_platform.d/*nvidia*.json; do
+    [ -f "$f" ] || continue
+    dst="/usr/share${f#$EGL_SRC}"
+    [ -f "$dst" ] || install -D -m 0644 "$f" "$dst"
+  done
+fi
+nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml >/dev/null 2>&1
+if [ -f /etc/cdi/nvidia.yaml ] && ! grep -q GBM_BACKENDS_PATH /etc/cdi/nvidia.yaml; then
+  sed -i '/^    env:$/a\        - GBM_BACKENDS_PATH=/usr/lib64/gbm:/usr/lib/x86_64-linux-gnu/gbm:/usr/lib/aarch64-linux-gnu/gbm' /etc/cdi/nvidia.yaml
+fi


### PR DESCRIPTION
## Problem

Containers using the nvidia GPU via `--gpus all` (CDI) on Unraid hit two issues:

1. **Black screen** in apps using GBM (wlroots / Selkies / pixelflux / etc.) because libgbm searches `/usr/lib/x86_64-linux-gnu/gbm/` in Debian-based containers but the driver only mounts `nvidia-drm_gbm.so` at `/usr/lib64/gbm/`.
2. **`Failed to create EGL display, falling back to Software Renderer (Pixman)`** because the generated `/etc/cdi/nvidia.yaml` does not mount the EGL/GLVND vendor JSONs. Without `10_nvidia.json` and friends, libEGL in the container only sees mesa and refuses the nvidia GBM device.

Root cause for (2): the NVIDIA installer writes these JSONs to fixed system paths (`/usr/share/glvnd/egl_vendor.d/`, `/usr/share/egl/egl_external_platform.d/`) that ignore `--x-prefix`, so `compile.sh` never captures them and they never end up on the host. `nvidia-ctk`'s graphics discoverer then has nothing to include.

## Solution

Three small changes:

- `source/usr/local/emhttp/plugins/nvidia-driver/event/disks_mounted` (new) — a disks_mounted event hook that stages the EGL/GLVND JSONs from the libnvidia-container volume into `/usr/share/`, runs "nvidia-ctk cdi generate", and appends `GBM_BACKENDS_PATH=/usr/lib64/gbm:/usr/lib/x86_64-linux-gnu/gbm:/usr/lib/aarch64-linux-gnu/gbm` to the CDI spec's `containerEdits.env` to fix the GBM black-screen. Unraid fires this event during `cmdStart` after the cache disk is mounted and before `rc.docker` starts the daemon, so the CDI is always complete by the time containers see it. Packaged into the plugin .txz by the existing `source/makepkg-unraid.sh`.
- nvidia-driver.plg `generate_cdi()` — now just invokes the event hook directly `([ -x &emhttp;/event/disks_mounted ] && &emhttp;/event/disks_mounted)`. This keeps the install/upgrade flow synchronous: on manual install or auto-update the `.txz` lands the hook on disk first, then `generate_cdi()` runs it immediately — no reboot or array restart required. On boot Unraid fires the event itself.
- `source/compile.sh` — after running the NVIDIA installer, copy *nvidia*.json from the installer's system paths into `/NVIDIA/usr/share/` so the driver `.txz` installs them on the host. Same pattern already used for `/etc/vulkan` and `/etc/OpenCL`. With the JSONs present on the host, nvidia-ctk's graphics discoverer picks them up automatically — meaning the hook's volume-staging step becomes a no-op on fresh installs once new driver packages are released, while still working as a safety net for existing installs.

## Why this is needed

Without this fix, any container that does EGL on the nvidia GPU without an X server — Wayland compositors, wlroots-based apps, Selkies/pixelflux, headless GL, OBS Wayland, Chromium ANGLE/EGL, etc. — silently falls back to software rendering and runs at single-digit / low double-digit FPS. With the fix, hardware acceleration works out of the box.

## Testing

Verified on Unraid 7.3.0, driver 595.71.05, nvidia-ctk 1.19.0:

- After staging the JSONs at `/usr/share/glvnd/egl_vendor.d/` and `/usr/share/egl/egl_external_platform.d/`, a fresh `nvidia-ctk cdi generate` includes `10_nvidia.json`, `10_nvidia_wayland.json`, and `15_nvidia_gbm.json` in the generated spec.
- `GBM_BACKENDS_PATH` lands cleanly under `containerEdits.env`.
- libEGL inside an affected container now initializes the nvidia EGL display instead of falling back to Pixman; performance returns to GPU-accelerated.


### Additionally
The specific problem was identified and the patch + the pr text was written using claude code, but i have thoroughly tested this and other proposed solutions using LSIO´s Docker-Steam container, which shows the problem very easily on affected systems (which are basically all systems with an nvidia gpu and no additional or disabled/not passed igpu). With the fixes in place the contaienr doesnt throw any GBM/EGL errors on boot anymore AND additionaly will massively increase FPS in containers that use this feature (this will probably include all LSIO selkies based containers, i noticed it the most in the docker-steam container, but could also see an improvement in the orca-slicer container).
All problems are described here https://forums.unraid.net/topic/98978-plugin-nvidia-driver/page/227/#findComment-1617328 and here https://github.com/linuxserver/docker-steam/issues/3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved NVIDIA driver configuration to ensure proper staging and setup of vendor JSON files during initialization.
  * Enhanced CDI generation process to automatically configure GPU backend paths when needed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unraid/unraid-nvidia-driver/pull/10?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->